### PR TITLE
Some updates

### DIFF
--- a/app/src/main/java/org/myhush/silentdragon/MainActivity.kt
+++ b/app/src/main/java/org/myhush/silentdragon/MainActivity.kt
@@ -160,7 +160,7 @@ class MainActivity : AppCompatActivity(),
                         lblBalance.text = "Balance"
                         txtMainBalance.text = balText + " ${DataModel.mainResponseData?.tokenName} "
                         //txtMainBalance.text = balText.substring(0, balText.length - 8) + " ${DataModel.mainResponseData?.tokenName} "
-                        txtMainBalanceUSD.text =  "$ " + DecimalFormat("#,##0.00").format(bal * zPrice)
+                        txtMainBalanceUSD.text =  "$" + DecimalFormat("#,##0.00").format(bal * zPrice)
 
                         // Enable the send and recieve buttons
                         bottomNav.menu.findItem(R.id.action_recieve).isEnabled = true

--- a/app/src/main/java/org/myhush/silentdragon/MainActivity.kt
+++ b/app/src/main/java/org/myhush/silentdragon/MainActivity.kt
@@ -155,11 +155,11 @@ class MainActivity : AppCompatActivity(),
                     } else {
                         val bal = DataModel.mainResponseData?.balance ?: 0.0
                         val zPrice = DataModel.mainResponseData?.zecprice ?: 0.0
-
                         val balText = DecimalFormat("#0.00000000").format(bal)
 
                         lblBalance.text = "Balance"
-                        txtMainBalance.text = balText.substring(0, balText.length - 4) + " ${DataModel.mainResponseData?.tokenName} "
+                        txtMainBalance.text = balText + " ${DataModel.mainResponseData?.tokenName} "
+                        //txtMainBalance.text = balText.substring(0, balText.length - 8) + " ${DataModel.mainResponseData?.tokenName} "
                         txtMainBalanceUSD.text =  "$ " + DecimalFormat("#,##0.00").format(bal * zPrice)
 
                         // Enable the send and recieve buttons

--- a/app/src/main/java/org/myhush/silentdragon/MainActivity.kt
+++ b/app/src/main/java/org/myhush/silentdragon/MainActivity.kt
@@ -160,7 +160,7 @@ class MainActivity : AppCompatActivity(),
                         lblBalance.text = "Balance"
                         txtMainBalance.text = balText + " ${DataModel.mainResponseData?.tokenName} "
                         //txtMainBalance.text = balText.substring(0, balText.length - 8) + " ${DataModel.mainResponseData?.tokenName} "
-                        txtMainBalanceUSD.text =  "$" + DecimalFormat("#,##0.00").format(bal * zPrice)
+                        txtMainBalanceUSD.text =  "$" + DecimalFormat("###,###,##0.00").format(bal * zPrice)
 
                         // Enable the send and recieve buttons
                         bottomNav.menu.findItem(R.id.action_recieve).isEnabled = true

--- a/app/src/main/java/org/myhush/silentdragon/ReceiveActivity.kt
+++ b/app/src/main/java/org/myhush/silentdragon/ReceiveActivity.kt
@@ -81,7 +81,7 @@ class ReceiveActivity : AppCompatActivity() {
 
         addrTxt.setOnClickListener {
             val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-            val clip = ClipData.newPlainText("Hush address", addr)
+            val clip = ClipData.newPlainText("HUSH address", addr)
             clipboard.primaryClip = clip
             Toast.makeText(applicationContext, "Copied address to clipboard", Toast.LENGTH_SHORT).show()
         }
@@ -89,13 +89,13 @@ class ReceiveActivity : AppCompatActivity() {
 
     fun setTAddr() {
         addr = DataModel.mainResponseData?.tAddress ?: ""
-        txtRcvAddrTitle.text = "Your Hush transparent address"
+        txtRcvAddrTitle.text = "Your HUSH transparent address"
         setAddr()
     }
 
     fun setZAddr() {
         addr = DataModel.mainResponseData?.saplingAddress ?: ""
-        txtRcvAddrTitle.text = "Your Hush shielded address"
+        txtRcvAddrTitle.text = "Your HUSH shielded address"
         setAddr()
     }
 

--- a/app/src/main/java/org/myhush/silentdragon/SendActivity.kt
+++ b/app/src/main/java/org/myhush/silentdragon/SendActivity.kt
@@ -70,7 +70,7 @@ class SendActivity : AppCompatActivity() {
                         R.color.white_selected
                     ))
                 } else {
-                    txtValidAddress.text = "Not a valid Hush address!"
+                    txtValidAddress.text = "Not a valid HUSH address!"
                     txtValidAddress.setTextColor(ContextCompat.getColor(applicationContext, R.color.colorAccent))
                 }
 

--- a/app/src/main/java/org/myhush/silentdragon/SendActivity.kt
+++ b/app/src/main/java/org/myhush/silentdragon/SendActivity.kt
@@ -163,7 +163,7 @@ class SendActivity : AppCompatActivity() {
 
                 val alertDialog = AlertDialog.Builder(this@SendActivity)
                 alertDialog.setTitle("Send from TADDR ?")
-                alertDialog.setMessage("${DataModel.mainResponseData?.tokenName} $amt is more than the balance in " +
+                alertDialog.setMessage("$amt ${DataModel.mainResponseData?.tokenName} is more than the balance in " +
                         "your shielded address. This Tx will have to be sent from a transparent address, and will" +
                         " not be private.\n\nAre you absolutely sure?")
                 alertDialog.apply {

--- a/app/src/main/java/org/myhush/silentdragon/SendActivity.kt
+++ b/app/src/main/java/org/myhush/silentdragon/SendActivity.kt
@@ -78,7 +78,7 @@ class SendActivity : AppCompatActivity() {
                     txtSendMemo.isEnabled       = false
                     chkIncludeReplyTo.isEnabled = false
                     txtSendMemo.text            = SpannableStringBuilder("")
-                    txtSendMemoTitle.text       = "(No Memo for t-Addresses)"
+                    txtSendMemoTitle.text       = "(No Memo for TADDR)"
                 } else {
                     txtSendMemo.isEnabled = true
                     chkIncludeReplyTo.isEnabled = true
@@ -162,7 +162,7 @@ class SendActivity : AppCompatActivity() {
                 amt.toDouble() <= DataModel.mainResponseData?.maxspendable ?: Double.MAX_VALUE) {
 
                 val alertDialog = AlertDialog.Builder(this@SendActivity)
-                alertDialog.setTitle("Send from t-addr?")
+                alertDialog.setTitle("Send from TADDR ?")
                 alertDialog.setMessage("${DataModel.mainResponseData?.tokenName} $amt is more than the balance in " +
                         "your shielded address. This Tx will have to be sent from a transparent address, and will" +
                         " not be private.\n\nAre you absolutely sure?")

--- a/app/src/main/java/org/myhush/silentdragon/SendActivity.kt
+++ b/app/src/main/java/org/myhush/silentdragon/SendActivity.kt
@@ -98,16 +98,17 @@ class SendActivity : AppCompatActivity() {
 
                 if (hush == null) {
                     txtSendCurrencySymbol.text = "" // Let the placeholder show the "$" sign
-                } else {
+                }
+                else
+                {
                     txtSendCurrencySymbol.text = "HUSH"
 
-
                     if (hush == null || zprice == null)
-                    amountUSD.text = "$ 0.0"
-                else
+                    amountUSD.text = "$0.0"
+                        else
                     amountUSD.text =
-                         " $"   + DecimalFormat("#.########").format(hush * zprice)
-            }
+                         "$"   + DecimalFormat("#.########").format(hush * zprice)
+                }
             }
         })
 
@@ -253,7 +254,7 @@ class SendActivity : AppCompatActivity() {
         val zprice = DataModel.mainResponseData?.zecprice
 
         if (amt == null || zprice == null)
-            amountUSD.text = "0.0 $"
+            amountUSD.text = "$0.0"
         else
             amountUSD.text =
                 "$" + DecimalFormat("#.########").format(amt)

--- a/app/src/main/java/org/myhush/silentdragon/SendActivity.kt
+++ b/app/src/main/java/org/myhush/silentdragon/SendActivity.kt
@@ -141,7 +141,7 @@ class SendActivity : AppCompatActivity() {
         // First, check if the address is correct.
         val toAddr = sendAddress.text.toString()
         if (!DataModel.isValidAddress(toAddr)) {
-            showErrorDialog("Invalid destination Hush address!")
+            showErrorDialog("Invalid destination HUSH address!")
             return
         }
 

--- a/app/src/main/java/org/myhush/silentdragon/SendActivity.kt
+++ b/app/src/main/java/org/myhush/silentdragon/SendActivity.kt
@@ -106,8 +106,7 @@ class SendActivity : AppCompatActivity() {
                     if (hush == null || zprice == null)
                     amountUSD.text = "$0.0"
                         else
-                    amountUSD.text =
-                         "$"   + DecimalFormat("#.########").format(hush * zprice)
+                    amountUSD.text = "$" + DecimalFormat("###,###,##0.00").format(hush * zprice)
                 }
             }
         })
@@ -246,8 +245,7 @@ class SendActivity : AppCompatActivity() {
         val zprice = DataModel.mainResponseData?.zecprice ?: 0.0
         amountHUSH.setText((DecimalFormat("#.########").format(amt) + "${DataModel.mainResponseData?.tokenName}"))
 
-        amountUSD.text =
-             "$" + DecimalFormat("#.########").format(amt)
+        amountUSD.text = "$" + DecimalFormat("###,###,##0.00").format(amt)
     }
 
     private fun setAmount(amt: Double?) {
@@ -256,9 +254,7 @@ class SendActivity : AppCompatActivity() {
         if (amt == null || zprice == null)
             amountUSD.text = "$0.0"
         else
-            amountUSD.text =
-                "$" + DecimalFormat("#.########").format(amt)
-
+            amountUSD.text = "$" + DecimalFormat("###,###,##0.00").format(amt)
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {

--- a/app/src/main/java/org/myhush/silentdragon/TxDetailsActivity.kt
+++ b/app/src/main/java/org/myhush/silentdragon/TxDetailsActivity.kt
@@ -60,7 +60,7 @@ class TxDetailsActivity : AppCompatActivity() {
         val amtStr = DecimalFormat("#0.0000####").format(amt)
 
         txtAmtHush.text = " $amtStr  ${DataModel.mainResponseData?.tokenName}"
-        txtAmtUSD.text =  "$" + DecimalFormat("#,##0.00").format(
+        txtAmtUSD.text =  "$" + DecimalFormat("###,###,##0.00").format(
             (amt) * (DataModel.mainResponseData?.zecprice ?: 0.0))
 
         if (tx?.memo.isNullOrBlank()) {

--- a/app/src/main/java/org/myhush/silentdragon/UnconfirmedTxItemFragment.kt
+++ b/app/src/main/java/org/myhush/silentdragon/UnconfirmedTxItemFragment.kt
@@ -55,7 +55,7 @@ class UnconfirmedTxItemFragment : Fragment() {
         }
 
         val txt = view.findViewById<TextView>(R.id.txtUnconfirmedTx)
-        txt.text = (if (tx?.type == "send") "Sending" else "Receiving") +
+        txt.text = (if (tx?.type == "send") "Sending " else "Receiving ") +
                     DecimalFormat("#0.00########").format(kotlin.math.abs(tx?.amount?.toDoubleOrNull() ?: 0.0)) +  " ${DataModel.mainResponseData?.tokenName} "
 
         return view

--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -30,7 +30,7 @@
         android:id="@+id/txtMainBalance"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="0.0 Hush"
+        android:text="0.00 HUSH"
         android:textColor="@android:color/white"
         android:textSize="30sp"
         app:layout_constraintBottom_toTopOf="@+id/txtMainBalanceUSD"

--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -45,7 +45,7 @@
         android:layout_marginStart="154dp"
         android:layout_marginEnd="154dp"
         android:layout_marginBottom="32dp"
-        android:text="0.0 $"
+        android:text="$0.0"
         android:textColor="@color/light_grey"
         app:layout_constraintBottom_toBottomOf="@+id/imageView2"
         app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -30,7 +30,7 @@
         android:id="@+id/txtMainBalance"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="0.00 HUSH"
+        android:text="XXXXXX.XXXXXXXX HUSH"
         android:textColor="@android:color/white"
         android:textSize="30sp"
         app:layout_constraintBottom_toTopOf="@+id/txtMainBalanceUSD"

--- a/app/src/main/res/layout/content_receive.xml
+++ b/app/src/main/res/layout/content_receive.xml
@@ -33,7 +33,7 @@
             android:layout_height="wrap_content"
             app:layout_constraintStart_toStartOf="parent" app:layout_constraintEnd_toEndOf="parent"
             android:id="@+id/txtRcvAddrTitle" android:layout_marginTop="16dp"
-            app:layout_constraintTop_toBottomOf="@+id/imageView" android:textColor="@color/colorPrimary"/>
+            app:layout_constraintTop_toBottomOf="@+id/imageView" android:textColor="@color/light_grey"/>
     <android.support.design.widget.TabLayout
             android:layout_width="395dp"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/content_receive.xml
+++ b/app/src/main/res/layout/content_receive.xml
@@ -28,7 +28,7 @@
             android:textSize="24sp" android:fontFamily="monospace" android:layout_marginTop="8dp"
             app:layout_constraintTop_toBottomOf="@+id/txtRcvAddrTitle" app:layout_constraintVertical_bias="0.0"/>
     <TextView
-            android:text="Your Hush Sapling Address"
+            android:text="Your HUSH Sapling Address"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             app:layout_constraintStart_toStartOf="parent" app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/content_send.xml
+++ b/app/src/main/res/layout/content_send.xml
@@ -100,7 +100,7 @@
                     android:layout_width="173dp"
                     android:layout_height="66dp"
                     android:layout_marginTop="16dp"
-                    android:hint="0.00 Hush"
+                    android:hint="0.00 HUSH"
                     android:inputType="numberDecimal"
                     android:maxLength="14"
                     android:selectAllOnFocus="true"

--- a/app/src/main/res/layout/content_send.xml
+++ b/app/src/main/res/layout/content_send.xml
@@ -118,7 +118,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginBottom="16dp"
-                    android:text="$ 0.00"
+                    android:text="$0.00"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/content_tx_details.xml
+++ b/app/src/main/res/layout/content_tx_details.xml
@@ -122,7 +122,7 @@
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@+id/textView6" />
                 <TextView
-                        android:text="$ 45.23"
+                        android:text="$45.23"
                         android:layout_width="0dp"
                         android:layout_height="wrap_content" android:id="@+id/txtAmtUSD"
                         android:layout_marginTop="8dp"

--- a/app/src/main/res/layout/fragment_unconfirmed_tx_item.xml
+++ b/app/src/main/res/layout/fragment_unconfirmed_tx_item.xml
@@ -38,7 +38,7 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="24dp"
             android:layout_marginTop="8dp"
-            android:text="Recieving HUSH 0.12345678"
+            android:text="Receiving 0.12345678 HUSH"
             android:textSize="18sp"
             app:layout_constraintStart_toEndOf="@+id/prgUnconfirmed"
             app:layout_constraintTop_toTopOf="parent" />


### PR DESCRIPTION
- Correct some text in gray on dark gray on 'Receive' page #19
- Add a space character between the word 'Receiving' and the amount in HUSH #21
- The balance is now not truncated. #22
- Standardization of the name HUSH #23
- 'HUSH' now visible after the amount on 'Send Transaction' page #25
- Standardization of the TADDR name
- Standardization of the display of amounts in $
- Maximum 2 decimals for amounts in $ and formatting