### PR TITLE
Update

### DIFF
--- a/app/src/main/java/org/myhush/silentdragon/MainActivity.kt
+++ b/app/src/main/java/org/myhush/silentdragon/MainActivity.kt
@@ -170,7 +170,7 @@ class MainActivity : AppCompatActivity(),
                         val balText = DecimalFormat("#0.00000000").format(bal)
 
                         lblBalance.text = "Balance"
-                        txtMainBalance.text = balText.substring(0, balText.length - 4) + " ${DataModel.mainResponseData?.tokenName} "
+                        txtMainBalance.text = balText + " ${DataModel.mainResponseData?.tokenName} "
                         if(cur.length > 1)
                             txtMainBalanceUSD.text =  "${DataModel.currencySymbols[cur]} " + DecimalFormat("0.00000000").format(bal * price)
                         else

--- a/app/src/main/java/org/myhush/silentdragon/MainActivity.kt
+++ b/app/src/main/java/org/myhush/silentdragon/MainActivity.kt
@@ -68,8 +68,15 @@ class MainActivity : AppCompatActivity(),
         }
 
         txtMainBalanceUSD.setOnClickListener {
-            Toast.makeText(applicationContext, "1 HUSH = ${DataModel.currencySymbols[DataModel.selectedCurrency]}${DecimalFormat("#.##")
+
+
+            if(DataModel.selectedCurrency == "BTC")
+                Toast.makeText(applicationContext, "1 HUSH = ${DataModel.currencySymbols[DataModel.selectedCurrency]}${DecimalFormat(" #,##0.00000000")
+                    .format(DataModel.currencyValues[DataModel.selectedCurrency])}", Toast.LENGTH_LONG).show()
+            else(
+                Toast.makeText(applicationContext, "1 HUSH = ${DataModel.currencySymbols[DataModel.selectedCurrency]}${DecimalFormat("#,##0.00")
                 .format(DataModel.currencyValues[DataModel.selectedCurrency])}", Toast.LENGTH_LONG).show()
+                    )
         }
 
         bottomNav.setOnNavigationItemSelectedListener {
@@ -171,7 +178,7 @@ class MainActivity : AppCompatActivity(),
 
                         lblBalance.text = "Balance"
                         txtMainBalance.text = balText + " ${DataModel.mainResponseData?.tokenName} "
-                        if(cur.length > 1)
+                        if(cur == "BTC")
                             txtMainBalanceUSD.text =  "${DataModel.currencySymbols[cur]} " + DecimalFormat("0.00000000").format(bal * price)
                         else
                             txtMainBalanceUSD.text =  "${DataModel.currencySymbols[cur]} " + DecimalFormat("#,##0.00").format(bal * price)

--- a/app/src/main/java/org/myhush/silentdragon/SendActivity.kt
+++ b/app/src/main/java/org/myhush/silentdragon/SendActivity.kt
@@ -115,7 +115,7 @@ class SendActivity : AppCompatActivity() {
                 if (hush == null || price == null)
                     amountUSD.text = "$symbol 0.0"
                 else
-                    amountUSD.text = "$symbol " + DecimalFormat("#.########").format(hush * price)
+                    amountUSD.text = "$symbol " + DecimalFormat("#,##0.00").format(hush * price)
             }
         })
 
@@ -251,8 +251,7 @@ class SendActivity : AppCompatActivity() {
         // HUSH field manually.
         amountHUSH.setText((DecimalFormat("#.########").format(amt) + "${DataModel.mainResponseData?.tokenName}"))
         Toast.makeText(this.applicationContext, amt.toString(), Toast.LENGTH_SHORT).show()
-        amountUSD.text =
-             "${DataModel.currencySymbols[DataModel.selectedCurrency]} " + DecimalFormat("#.########").format(amt)
+        amountUSD.text = "${DataModel.currencySymbols[DataModel.selectedCurrency]} " + DecimalFormat("#,##0.00").format(amt)
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {

--- a/app/src/main/java/org/myhush/silentdragon/SendActivity.kt
+++ b/app/src/main/java/org/myhush/silentdragon/SendActivity.kt
@@ -64,8 +64,14 @@ class SendActivity : AppCompatActivity() {
         if (DataModel.currencyValues["USD"] == null)
             ConnectionManager.initCurrencies()
 
-        amountUSD.text = "${DataModel.currencySymbols[DataModel.selectedCurrency]} 0.00"
-        textViewFee.text = "0.0001 HUSH"
+        if (DataModel.selectedCurrency == "BTC")
+            amountUSD.text = "${DataModel.currencySymbols[DataModel.selectedCurrency]} " + DecimalFormat("0.00000000").format(0)
+        else
+        {
+            amountUSD.text = "${DataModel.currencySymbols[DataModel.selectedCurrency]} " + DecimalFormat("0.00").format(0)
+        }
+
+        textViewFee.text = DecimalFormat("0.0000").format(0.0001) + " HUSH"
 
         sendAddress.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
@@ -113,9 +119,17 @@ class SendActivity : AppCompatActivity() {
                 }
 
                 if (hush == null || price == null)
-                    amountUSD.text = "$symbol 0.0"
+                    if (symbol == "BTC")
+                        amountUSD.text = "$symbol " + DecimalFormat("0.00000000").format(0)
+                    else {
+                        amountUSD.text = "$symbol " + DecimalFormat("0.00").format(0)
+                    }
                 else
-                    amountUSD.text = "$symbol " + DecimalFormat("#,##0.00").format(hush * price)
+                    if (symbol == "BTC")
+                        amountUSD.text = "$symbol " + DecimalFormat("#,##0.00000000").format(hush * price)
+                    else {
+                        amountUSD.text = "$symbol " + DecimalFormat("#,##0.00").format(hush * price)
+                    }
             }
         })
 

--- a/app/src/main/java/org/myhush/silentdragon/SendActivity.kt
+++ b/app/src/main/java/org/myhush/silentdragon/SendActivity.kt
@@ -171,7 +171,7 @@ class SendActivity : AppCompatActivity() {
 
                 val alertDialog = AlertDialog.Builder(this@SendActivity)
                 alertDialog.setTitle("Send from t-addr?")
-                alertDialog.setMessage("${DataModel.mainResponseData?.tokenName} $amt is more than the balance in " +
+                alertDialog.setMessage("$amt ${DataModel.mainResponseData?.tokenName} is more than the balance in " +
                         "your shielded address. This Tx will have to be sent from a transparent address, and will" +
                         " not be private.\n\nAre you absolutely sure?")
                 alertDialog.apply {

--- a/app/src/main/java/org/myhush/silentdragon/UnconfirmedTxItemFragment.kt
+++ b/app/src/main/java/org/myhush/silentdragon/UnconfirmedTxItemFragment.kt
@@ -56,7 +56,7 @@ class UnconfirmedTxItemFragment : Fragment() {
         }
 
         val txt = view.findViewById<TextView>(R.id.txtUnconfirmedTx)
-        txt.text = (if (tx?.type == "send") "Sending" else "Receiving") +
+        txt.text = (if (tx?.type == "send") "Sending " else "Receiving ") +
                     DecimalFormat("#0.00########").format(kotlin.math.abs(tx?.amount?.toDoubleOrNull() ?: 0.0)) +  " ${DataModel.mainResponseData?.tokenName} "
 
         return view

--- a/app/src/main/res/layout/content_receive.xml
+++ b/app/src/main/res/layout/content_receive.xml
@@ -33,7 +33,7 @@
             android:layout_height="wrap_content"
             app:layout_constraintStart_toStartOf="parent" app:layout_constraintEnd_toEndOf="parent"
             android:id="@+id/txtRcvAddrTitle" android:layout_marginTop="16dp"
-            app:layout_constraintTop_toBottomOf="@+id/imageView" android:textColor="@color/colorPrimary"/>
+            app:layout_constraintTop_toBottomOf="@+id/imageView" android:textColor="@color/light_grey"/>
     <android.support.design.widget.TabLayout
             android:layout_width="395dp"
             android:layout_height="wrap_content"


### PR DESCRIPTION
- Better display of amounts in BTC
- Correct some text in gray on dark gray on 'Receive' page #19
- 'HUSH' now visible after the amount on 'Send Transaction' page #25
- Add a space character between the word 'Receiving' and 'Sending'
- Maximum 2 decimals for amounts convertion
- The balance is now not truncated. #22
