### PR TITLE
Not render the eye link link before the transaction is sent

### DIFF
--- a/app/src/main/java/org/myhush/silentdragon/TxDetailsActivity.kt
+++ b/app/src/main/java/org/myhush/silentdragon/TxDetailsActivity.kt
@@ -39,6 +39,7 @@ class TxDetailsActivity : AppCompatActivity() {
             imgTypeColor.setImageResource(R.color.colorAccent)
 
         if (tx?.type == "confirm") {
+
             txtType.text = "Confirm Transaction"
             txtDateTime.text = ""
             btnExternal.text = "Confirm and Send"
@@ -119,6 +120,11 @@ class TxDetailsActivity : AppCompatActivity() {
 
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {
         menuInflater.inflate(R.menu.menu_txdetails, menu)
+
+        tx = Klaxon().parse(StringReader(intent.getStringExtra("EXTRA_TXDETAILS")))
+        if (tx?.type == "confirm") {
+            menu!!.removeItem(R.id.action_view)
+        }
         return true
     }
 


### PR DESCRIPTION
The link to the block explorer will no longer appear when the transaction has not been confirmed and sent.
This avoids the user to arrive on page 404 since the transaction has not yet taken place.

BEFORE: 
![Screenshot_20191123-234058_SilentDragon](https://user-images.githubusercontent.com/39105646/69502872-36b7d000-0f14-11ea-8395-12a38c268c2e.jpg)

AFTER:
![Screenshot_20191124-232619_SilentDragon](https://user-images.githubusercontent.com/39105646/69502871-361f3980-0f14-11ea-83f9-050ce98cdc27.jpg)

- 404 Page not found when clic on eyes of 'Confirm & send 'page #52

