### PR TITLE
Fix build errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,5 +58,7 @@ freeline_project_description.json
 
 secrets.properties
 
+!examples/*
+
 # vim
 *.sw?

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Make sure you have Gradle 5.4.x or higher, 5.4.1 is known to work:
 
 ## Release Build Process
 
-The first time you create a release build you'll need to create two files. The
+The first time you create a release build you'll need to create a keystore file and prepare a properties file. The
 release keystore is used for app signing and a properties file is used to store
 sensitive information about the keystore. These files should not be committed
 to git. Once you have both of these files you can create a release build for
@@ -84,18 +84,10 @@ The `keytool` command can be used, for example:
 * Set the Key Store Name to `silent_dragon_keystore.jks` and the path to that of the project, create a password for the keystore path, a Key alias, and a key password. The store password and key password should be the same. Fill out some basic organization information and click Ok.
 * On the next screen make sure the build variant "release" is selected and click Finish.
 
-### Creating a properties file
+### Preparing properties file
 
-Within the projects main directory create a file secrets.properties The
-contents of the file are below and filled in with the release keystore alias,
-key password, and store password from when you created the release keystore.
-
-```
-store_file_location=../silent_dragon_keystore.jks
-key_alias=<alias>
-key_password=<key_password>
-store_password=<store_password>
-```
+Copy `secrets.properties` file from `examples` folder and paste it to the projects main directory.
+Fill store_file_location, key_alias, key_password and store_password when you created the release keystore.
 
 ### Building a release APK for Google Play
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,13 +5,6 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
-def secretsPropertiesFile = rootProject.file("secrets.properties")
-def secretProperties = new Properties()
-
-if (secretsPropertiesFile.exists()) {
-    secretProperties.load(new FileInputStream((secretsPropertiesFile)))
-}
-
 android {
     compileSdkVersion 28
 
@@ -25,14 +18,8 @@ android {
         vectorDrawables.useSupportLibrary = true
     }
 
-
     signingConfigs {
-        release {
-            storeFile file(secretProperties["store_file_location"])
-            keyAlias secretProperties["key_alias"]
-            keyPassword secretProperties["key_password"]
-            storePassword secretProperties["store_password"]
-        }
+        release
     }
 
     buildTypes {
@@ -43,6 +30,22 @@ android {
         }
     }
 
+}
+
+def secretsPropertiesFile = rootProject.file("secrets.properties")
+def secretProperties = new Properties()
+
+if (secretsPropertiesFile.exists()) {
+    secretProperties.load(new FileInputStream(secretsPropertiesFile))
+
+    android.signingConfigs.release.storeFile = file(secretProperties["store_file_location"])
+    android.signingConfigs.release.keyAlias = secretProperties["key_alias"]
+    android.signingConfigs.release.keyPassword = secretProperties["key_password"]
+    android.signingConfigs.release.storePassword = secretProperties["store_password"]
+
+    android.buildTypes.release.signingConfig = android.signingConfigs.release
+} else {
+    android.buildTypes.release.signingConfig = null
 }
 
 dependencies {

--- a/examples/secrets.properties
+++ b/examples/secrets.properties
@@ -1,0 +1,4 @@
+store_file_location=../silent_dragon_keystore.jks
+key_alias=<alias>
+key_password=<key_password>
+store_password=<store_password>


### PR DESCRIPTION
When the first time you want to build the SDA; you get some errors about keystore file but maybe you just want to contribute to SDA or you don't care about keystore. 

So with this PR we'll check if there is a properties file and get informations from there instead of trying to get them directly which is cause of error.

That also should fix Travis build errors just like fixing our errors.